### PR TITLE
Account: Rework validateAuthProvider() logic.

### DIFF
--- a/lib/Data/Models/Client.php
+++ b/lib/Data/Models/Client.php
@@ -61,15 +61,11 @@ class Client extends \FeideConnect\Data\Model {
     }
 
     public function getAuthProviders() {
-        $res = [];
-        if (empty($this->authproviders)) {
-            return [["all"]];
+        if (!empty($this->authproviders)) {
+            return $this->authproviders;
+        } else {
+            return ['all'];
         }
-        foreach ($this->authproviders as $a) {
-            $res[] = explode('|', $a);
-        }
-        return $res;
-
     }
 
     public function getOrgAuthorization($realm) {

--- a/tests/AccountTest.php
+++ b/tests/AccountTest.php
@@ -374,24 +374,14 @@ class AccountTest extends DBHelper {
     }
 
 
-    public function testCompareType() {
-        $this->assertTrue(Account::compareType(['ugle'], []));
-        $this->assertTrue(Account::compareType(['ugle'], ['ugle']));
-        $this->assertTrue(Account::compareType(['ugle'], ['ugle', 'all']));
-        $this->assertTrue(Account::compareType(['ugle', 'foo'], ['ugle', 'all']));
-        $this->assertTrue(Account::compareType(['ugle', 'foo', 'bar'], ['ugle', 'all']));
-        $this->assertFalse(Account::compareType([], ['ugle']));
-        $this->assertFalse(Account::compareType(['foo'], ['ugle']));
-    }
-
     public function testValidateAuthProviderOK() {
         $account = new Account([
             'eduPersonPrincipalName' => ['test@example.org'],
             'idp' => self::$feideidp,
         ], self::$feideAM);
-        $this->assertTrue($account->validateAuthProvider([]));
-        $this->assertTrue($account->validateAuthProvider([['all']]));
-        $this->assertTrue($account->validateAuthProvider([['feide', 'all']]));
+        $this->assertTrue($account->validateAuthProvider(['all']));
+        $this->assertTrue($account->validateAuthProvider(['feide|all']));
+        $this->assertTrue($account->validateAuthProvider(['feide|realm|example.org']));
     }
 
     public function testValidateAuthProviderFail() {
@@ -400,7 +390,7 @@ class AccountTest extends DBHelper {
             'eduPersonPrincipalName' => ['test@example.org'],
             'idp' => self::$feideidp,
         ], self::$feideAM);
-        $account->validateAuthProvider([['social', 'facebook']]);
+        $account->validateAuthProvider(['social|facebook']);
     }
 
     public function testAgeLimit() {


### PR DESCRIPTION
This patch changes the account access check logic in validateAuthProvider().
The new method simply finds all possibilities from the current acount, and
intersect them with the ones allowed by the service. If the intersection it
means that the current account is allowed for this service, and the login
is allowed