### PR TITLE
Sort organizations on client

### DIFF
--- a/lib/Controllers/Data.php
+++ b/lib/Controllers/Data.php
@@ -69,12 +69,6 @@ class Data {
 
     public static function getOrgs() {
 
-        $lat = $lon = null;
-        if (isset($_REQUEST['lat']) && is_numeric($_REQUEST['lat']) && isset($_REQUEST['lon']) && is_numeric($_REQUEST['lon'])) {
-            $lat = floatval($_REQUEST['lat']);
-            $lon = floatval($_REQUEST['lon']);
-        }
-
         $storage = StorageProvider::getStorage();
         $orgs = $storage->getOrgsByService('auth');
         $data = [];
@@ -84,7 +78,7 @@ class Data {
                 continue;
             }
             // if (!in_array($org->realm, $subscribers)) { continue; }
-            $di = $org->getOrgInfo($lat, $lon);
+            $di = $org->getOrgInfo();
             $data[] = $di;
         }
 

--- a/lib/Controllers/Data.php
+++ b/lib/Controllers/Data.php
@@ -57,16 +57,6 @@ class Data {
         return $response;
     }
 
-    public static function scmp($a, $b) {
-
-
-        $ax = ($a["distance"] === null ? 9999 : $a["distance"]);
-        $bx = ($b["distance"] === null ? 9999 : $b["distance"]);
-
-
-        return ($ax < $bx) ? -1 : 1;
-    }
-
     public static function getOrgs() {
 
         $storage = StorageProvider::getStorage();
@@ -81,9 +71,6 @@ class Data {
             $di = $org->getOrgInfo();
             $data[] = $di;
         }
-
-        usort($data, ["\FeideConnect\Controllers\Data", "scmp"]);
-
 
         // echo '<pre>';
         // foreach($data as $d) {

--- a/lib/Data/Models/Organization.php
+++ b/lib/Data/Models/Organization.php
@@ -70,8 +70,6 @@ class Organization extends \FeideConnect\Data\Model {
         }
         $res["services"] = $prepared["services"];
 
-        $res["distance"] = null;
-
         return $res;
     }
 

--- a/lib/Data/Models/Organization.php
+++ b/lib/Data/Models/Organization.php
@@ -52,35 +52,12 @@ class Organization extends \FeideConnect\Data\Model {
 
     }
 
-    public function distance($lat, $lon) {
-
-        if (!isset($this->uiinfo)) {
-            return null;
-        }
-        if (!isset($this->uiinfo["geo"])) {
-            return null;
-        }
-        if (!is_array($this->uiinfo["geo"])) {
-            return null;
-        }
-
-        $distance = 9999;
-        foreach ($this->uiinfo["geo"] as $geoitem) {
-            $dc = Misc::distance($lat, $lon, $geoitem["lat"], $geoitem["lon"]);
-            if ($dc < $distance) {
-                $distance = $dc;
-            }
-        }
-        return $distance;
-    }
-
-
     public function getName() {
         $lang = Misc::getBrowserLanguage(array_keys($this->name));
         return $this->name[$lang];
     }
 
-    public function getOrgInfo($lat = null, $lon = null) {
+    public function getOrgInfo() {
 
         $res = [];
         $prepared = parent::getAsArray();
@@ -93,11 +70,7 @@ class Organization extends \FeideConnect\Data\Model {
         }
         $res["services"] = $prepared["services"];
 
-        if ($lat !== null && $lon !== null) {
-            $res["distance"] = $this->distance($lat, $lon);
-        } else {
-            $res["distance"] = null;
-        }
+        $res["distance"] = null;
 
         return $res;
     }

--- a/lib/Utils/Misc.php
+++ b/lib/Utils/Misc.php
@@ -106,43 +106,6 @@ class Misc {
     }
 
 
-
-    /*::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::*/
-    /*::                                                                         :*/
-    /*::  This routine calculates the distance between two points (given the     :*/
-    /*::  latitude/longitude of those points). It is being used to calculate     :*/
-    /*::  the distance between two locations using GeoDataSource(TM) Products    :*/
-    /*::                                                                         :*/
-    /*::  Definitions:                                                           :*/
-    /*::    South latitudes are negative, east longitudes are positive           :*/
-    /*::                                                                         :*/
-    /*::  Passed to function:                                                    :*/
-    /*::    lat1, lon1 = Latitude and Longitude of point 1 (in decimal degrees)  :*/
-    /*::    lat2, lon2 = Latitude and Longitude of point 2 (in decimal degrees)  :*/
-    /*::    unit = the unit you desire for results                               :*/
-    /*::           where: 'M' is statute miles (default)                         :*/
-    /*::                  'K' is kilometers                                      :*/
-    /*::                  'N' is nautical miles                                  :*/
-    /*::  Worldwide cities and other features databases with latitude longitude  :*/
-    /*::  are available at http://www.geodatasource.com                          :*/
-    /*::                                                                         :*/
-    /*::  For enquiries, please contact sales@geodatasource.com                  :*/
-    /*::                                                                         :*/
-    /*::  Official Web site: http://www.geodatasource.com                        :*/
-    /*::                                                                         :*/
-    /*::         GeoDataSource.com (C) All Rights Reserved 2015                        :*/
-    /*::                                                                         :*/
-    /*::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::*/
-    public static function distance($lat1, $lon1, $lat2, $lon2) {
-
-        $theta = $lon1 - $lon2;
-        $dist = sin(deg2rad($lat1)) * sin(deg2rad($lat2)) +  cos(deg2rad($lat1)) * cos(deg2rad($lat2)) * cos(deg2rad($theta));
-        $dist = acos($dist);
-        $dist = rad2deg($dist);
-        $kilometers = $dist * 60 * 1.1515 * 1.609344;
-        return $kilometers;
-    }
-
     public static function randomShort() {
         return unpack('n', openssl_random_pseudo_bytes(2))[1];
     }

--- a/www/static/accountchooser/DiscoveryController.js
+++ b/www/static/accountchooser/DiscoveryController.js
@@ -268,8 +268,7 @@ define(function(require, exports, module) {
 
         "loadData": function() {
             var that = this;
-            var loc = this.location.getLocation();
-            $.getJSON('/orgs?lat=' + loc.lat + '&lon=' + loc.lon + '', function(orgs) {
+            $.getJSON('/orgs', function(orgs) {
 
                 that.orgs = [];
                 for(var i = 0; i < orgs.length; i++) {
@@ -457,10 +456,8 @@ define(function(require, exports, module) {
 
             }
 
-            if (this.country !== 'no') {
-                var sf = this.getCompareDistanceFunc();
-                showit.sort(sf);
-            }
+            var sf = this.getCompareDistanceFunc();
+            showit.sort(sf);
 
             for (i = 0; i < showit.length; i++) {
 

--- a/www/static/accountchooser/models/NorwegianOrg.js
+++ b/www/static/accountchooser/models/NorwegianOrg.js
@@ -14,14 +14,17 @@ define(function(require, exports, module) {
             this._super(a);
         },
         "getDistance": function(loc) {
-
-            if (this.hasOwnProperty("geo") && this.geo.hasOwnProperty("lat") && this.geo.hasOwnProperty("lon")) {
-                var dist = Utils.calculateDistance(loc.lat, loc.lon, this.geo.lat, this.geo.lon);
-                return dist;
+            var minDistance = 9999;
+            if (this.hasOwnProperty("uiinfo") && this.uiinfo.hasOwnProperty("geo")) {
+                for (var i = 0; i < this.uiinfo.geo.length; i++) {
+                    var geo = this.uiinfo.geo[i];
+                    var dist = Utils.calculateDistance(loc.lat, loc.lon, geo.lat, geo.lon);
+                    if (dist < minDistance) {
+                        minDistance = dist;
+                    }
+                }
             }
-
-            return 9999;
-
+            return minDistance;
         },
         "isType": function(type) {
             if (!this.type) {


### PR DESCRIPTION
This patch set changes the sorting of the organization list to happen on the client in all cases, and not just for EduGAIN. This will increase the cache hit ratio for the `/orgs`-endpoint.
